### PR TITLE
Include instructions for cloning submodules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 The Civil First Fleet is an open source WordPress theme designed by Civil and developed by Alley for use by the First Fleet. This is a pre-beta release, and documentation is a work in progress, so proceed at your own caution and discretion.
 
 # Usage
-Download this repo and extract to `/wp-content/themes/civil-first-fleet/`.
+- Download this repo and extract to `/wp-content/themes/civil-first-fleet/`.
+- In the `civil-first-fleet/` directory, run `git submodule update --init --recursive` to fetch the submodules.
 
 ## Frontend Build
 This theme uses NPM to build frontend assets. Build scripts can be found in [package.json](https://github.com/alleyinteractive/civil-first-fleet/blob/master/package.json#L6-L14). To get started, you should `npm install` and `npm run build` from the theme root.


### PR DESCRIPTION
A regular `git clone` will not include the submodules, and nor will the GitHub download of the repo, so the theme will be immediately broken unless the submodules are also fetched.