### PR TITLE
CDM-32: add article list disable_backfill setting

### DIFF
--- a/components/content-list/class-content-list.php
+++ b/components/content-list/class-content-list.php
@@ -215,7 +215,9 @@ class Content_List extends \Civil_First_Fleet\Component {
 		);
 
 		// Do we need backfill post ids?
-		if ( count( $post_ids ) < $total_ids_needed ) {
+		$disable_backfill = $this->get_setting( 'disable_backfill' );
+
+		if ( ( count( $post_ids ) < $total_ids_needed ) && ! $disable_backfill ) {
 			$backfill_post_ids = $this->get_backfill_post_ids( $total_ids_needed - count( $post_ids ) );
 
 			// Merge backfill post ids.

--- a/components/featured-articles/class-featured-articles.php
+++ b/components/featured-articles/class-featured-articles.php
@@ -52,12 +52,12 @@ class Featured_Articles extends \Civil_First_Fleet\Component\Content_List {
 					'title'            => new \Fieldmanager_Textfield( __( 'Title', 'civil-first-fleet' ) ),
 					'hide_sidebar'     => new \Fieldmanager_Checkbox(
 						[
-							'label'       => __( 'Hide Sidebar (only display one post)', 'civil-first-fleet' ),
+							'label' => __( 'Hide Sidebar (only display one post)', 'civil-first-fleet' ),
 						]
 					),
 					'disable_backfill' => new \Fieldmanager_Checkbox(
 						[
-							'label'         => __( 'Disable Article Backfill (only display curated posts)', 'civil-first-fleet' ),
+							'label' => __( 'Disable Article Backfill (only display curated posts)', 'civil-first-fleet' ),
 						],
 					),
 					'call_to_action'   => new \Fieldmanager_Group(

--- a/components/featured-articles/class-featured-articles.php
+++ b/components/featured-articles/class-featured-articles.php
@@ -58,7 +58,7 @@ class Featured_Articles extends \Civil_First_Fleet\Component\Content_List {
 					'disable_backfill' => new \Fieldmanager_Checkbox(
 						[
 							'label'         => __( 'Disable Backfill', 'civil-first-fleet' ),
-							'description'   => __( 'Check this to only display curated posts.', 'civil-first-fleet' ),
+							'description'   => __( 'Check this setting to only display curated posts.', 'civil-first-fleet' ),
 						],
 					),
 					'call_to_action'   => new \Fieldmanager_Group(

--- a/components/featured-articles/class-featured-articles.php
+++ b/components/featured-articles/class-featured-articles.php
@@ -57,8 +57,7 @@ class Featured_Articles extends \Civil_First_Fleet\Component\Content_List {
 					),
 					'disable_backfill' => new \Fieldmanager_Checkbox(
 						[
-							'label'         => __( 'Disable Backfill', 'civil-first-fleet' ),
-							'description'   => __( 'Check this setting to only display curated posts.', 'civil-first-fleet' ),
+							'label'         => __( 'Disable Article Backfill (only display curated posts)', 'civil-first-fleet' ),
 						],
 					),
 					'call_to_action'   => new \Fieldmanager_Group(

--- a/components/featured-articles/class-featured-articles.php
+++ b/components/featured-articles/class-featured-articles.php
@@ -27,9 +27,10 @@ class Featured_Articles extends \Civil_First_Fleet\Component\Content_List {
 	 */
 	public function default_data() : array {
 		$data = parent::default_data();
-		$data['call_to_action'] = null;
-		$data['sponsorship']    = false;
-		$data['hide_sidebar']   = false;
+		$data['call_to_action']   = null;
+		$data['sponsorship']      = false;
+		$data['hide_sidebar']     = false;
+		$data['disable_backfill'] = false;
 		return $data;
 	}
 
@@ -48,20 +49,26 @@ class Featured_Articles extends \Civil_First_Fleet\Component\Content_List {
 				'label'     => __( 'Settings', 'civil-first-fleet' ),
 				'collapsed' => true,
 				'children'  => [
-					'title'          => new \Fieldmanager_Textfield( __( 'Title', 'civil-first-fleet' ) ),
-					'hide_sidebar'   => new \Fieldmanager_Checkbox(
+					'title'            => new \Fieldmanager_Textfield( __( 'Title', 'civil-first-fleet' ) ),
+					'hide_sidebar'     => new \Fieldmanager_Checkbox(
 						[
 							'label'       => __( 'Hide Sidebar (only display one post)', 'civil-first-fleet' ),
 						]
 					),
-					'call_to_action' => new \Fieldmanager_Group(
+					'disable_backfill' => new \Fieldmanager_Checkbox(
+						[
+							'label'         => __( 'Disable Backfill', 'civil-first-fleet' ),
+							'description'   => __( 'Check this to only display curated posts.', 'civil-first-fleet' ),
+						],
+					),
+					'call_to_action'   => new \Fieldmanager_Group(
 						[
 							'label'     => __( 'Call To Action', 'civil-first-fleet' ),
 							'collapsed' => true,
 							'children'  => call_to_action()->get_fm_fields(),
 						]
 					),
-					'sponsorship'    => new \Fieldmanager_Group(
+					'sponsorship'      => new \Fieldmanager_Group(
 						[
 							'label'    => __( 'Sponsors', 'civil-first-fleet' ),
 							'children' => \Civil_First_Fleet\Components\Sponsor::get_schedule_fm_fields(),
@@ -82,6 +89,7 @@ class Featured_Articles extends \Civil_First_Fleet\Component\Content_List {
 		$items               = absint( $this->get_setting( 'items' ) );
 		$hide_sidebar        = (bool) $this->get_data( 'meta', 'hide_sidebar' ) ?? false;
 		$show_call_to_action = (bool) $this->get_data( 'meta', 'call_to_action', 'enable' ) ?? false;
+		$disable_backfill    = (bool) $this->get_data( 'meta', 'disable_backfill' ) ?? false;
 
 		// Set the sponsorship data.
 		$this->set_data( 'sponsorship', $this->get_data( 'meta', 'sponsorship' ) );
@@ -94,6 +102,9 @@ class Featured_Articles extends \Civil_First_Fleet\Component\Content_List {
 			// Only 6 items if rendering a call to action.
 			$this->set_setting( 'items', 6 );
 		}
+
+		// Set backfill setting.
+		$this->set_setting( 'disable_backfill', $disable_backfill );
 	}
 }
 


### PR DESCRIPTION
https://alleyinteractive.atlassian.net/browse/CDM-32

Adds new `disable_backfill` setting to Featured Articles in order to limit the number of featured posts displayed on the homepage.