### PR TITLE
CDM-221: Dedupe article grid when middle feature is enabled

### DIFF
--- a/template-parts/homepage-ajax.php
+++ b/template-parts/homepage-ajax.php
@@ -17,6 +17,12 @@ $hide_sidebar = (bool) $homepage['featured_articles']['meta']['hide_sidebar'] ??
 	->get_content_items();
 
 // Replicate code ran on homepage to account for curated ids and backfill.
+\Civil_First_Fleet\Component\middle_feature()
+	->set_setting( 'items', 4 )
+	->data( $homepage['middle_feature'] ?? [] )
+	->get_content_items();
+
+// Replicate code ran on homepage to account for curated ids and backfill.
 \Civil_First_Fleet\Component\article_grid()
 	->set_setting( 'items', 9 )
 	->data( $homepage['articles_grid'] ?? [] )

--- a/template-parts/homepage-ajax.php
+++ b/template-parts/homepage-ajax.php
@@ -17,10 +17,12 @@ $hide_sidebar = (bool) $homepage['featured_articles']['meta']['hide_sidebar'] ??
 	->get_content_items();
 
 // Replicate code ran on homepage to account for curated ids and backfill.
-\Civil_First_Fleet\Component\middle_feature()
-	->set_setting( 'items', 4 )
-	->data( $homepage['middle_feature'] ?? [] )
-	->get_content_items();
+if ( ! empty( $homepage['middle_feature']['enable'] ) ) {
+	\Civil_First_Fleet\Component\middle_feature()
+		->set_setting( 'items', 4 )
+		->data( $homepage['middle_feature'] ?? [] )
+		->get_content_items();
+}
 
 // Replicate code ran on homepage to account for curated ids and backfill.
 \Civil_First_Fleet\Component\article_grid()


### PR DESCRIPTION
Sites with the Middle Feature enabled on the homepage are showing duplicate posts on load more. This accounts for those posts in the AJAX request to avoid duplication.

Ticket: https://alleyinteractive.atlassian.net/browse/CDM-221