### PR TITLE
CDM-252: remove additional meta if Yoast is active

### DIFF
--- a/inc/seo.php
+++ b/inc/seo.php
@@ -189,6 +189,11 @@ function generate_header_meta() {
  * Output a post's or page's social meta tags.
  */
 function social_meta() {
+	// Bail if Yoast is active.
+	if ( is_plugin_active( 'wordpress-seo/wp-seo.php' ) ) {
+		return;
+	}
+
 	if ( is_single() || is_page() || \Civil_First_Fleet\is_landing_page() || is_archive() ) {
 
 		$meta = generate_header_meta();


### PR DESCRIPTION
https://alleyinteractive.atlassian.net/browse/CDM-252
Update the theme to not add additional meta to the head if Yoast is active (preventing multiple definitions of the `og:image`).
