### PR TITLE
CDM-340: Refactor video flag setting to use single checkbox.

### DIFF
--- a/.scaffold
+++ b/.scaffold
@@ -3,7 +3,7 @@
   "cpt:landing-page": "ea1346afc6443add4adb31aa475d5a33",
   "fm:post-landing-page-settings": "607ba0e0c1f153e645425343fc2aa504",
   "fm:post-guest-author-info": "06dc346b9cc8805854b636a8db0717cd",
-  "fm:post-post-article-settings": "5fe6b16c6e82230245fb3b5ad788bb83",
+  "fm:post-post-article-settings": "de8efa5b6178ae93e1fb8a9fb38448db",
   "fm:submenu-newsroom-settings": "5445c9ce7ff9b1768a63fda4d5517192",
   "cpt:sponsor": "7440797aa6e92a1bbf911b2888f8040a",
   "fm:post-sponsor-settings": "91faec08ca16894b6f1e88d277ca87e3",

--- a/components/content-item/class-content-item.php
+++ b/components/content-item/class-content-item.php
@@ -284,17 +284,6 @@ class Content_Item extends \Civil_First_Fleet\Component {
 	}
 
 	/**
-	 * Return a list of available image labels.
-	 *
-	 * @return array List of image label options.
-	 */
-	public function get_image_label_options() {
-		return [
-			'video' => __( 'Is Video', 'civil-first-fleet' ),
-		];
-	}
-
-	/**
 	 * Get image label.
 	 *
 	 * @param int $post_id ID of post to get image label for.
@@ -302,8 +291,8 @@ class Content_Item extends \Civil_First_Fleet\Component {
 	 */
 	public function get_image_label( $post_id = null ) {
 		$post_id = $post_id ?? get_the_ID();
-		$labels  = get_post_meta( $post_id, 'image_label', true );
-		if ( is_array( $labels ) && in_array( 'video', $labels, true ) ) {
+		$label  = get_post_meta( $post_id, 'image_label', true );
+		if ( ! empty( $label ) ) {
 			return sprintf(
 				/* translators: 1: Label to identify video posts. */
 				'<span>%1$s</span>',

--- a/inc/fields.php
+++ b/inc/fields.php
@@ -417,6 +417,12 @@ function civil_first_fleet_fm_post_post_article_settings() {
 						'serialize_data' => false,
 						'add_to_prefix'  => false,
 						'children'       => [
+							'image_label'         => new Fieldmanager_Checkbox(
+								[
+									'label'       => __( 'Enable Video Flag', 'civil-first-fleet' ),
+									'description' => __( 'Indicates that this is a video post.', 'civil-first-fleet' ),
+								]
+							),
 							'dek'                 => new Fieldmanager_TextArea(
 								[
 									'label'      => __( 'Deck', 'civil-first-fleet' ),
@@ -443,12 +449,6 @@ function civil_first_fleet_fm_post_post_article_settings() {
 								[
 									'label'   => __( 'Enable Label', 'civil-first-fleet' ),
 									'options' => \Civil_First_Fleet\Component\Content_Item()->get_label_options(),
-								]
-							),
-							'image_label'         => new Fieldmanager_Checkboxes(
-								[
-									'label'   => __( 'Enable Image Label', 'civil-first-fleet' ),
-									'options' => \Civil_First_Fleet\Component\Content_Item()->get_image_label_options(),
 								]
 							),
 						],

--- a/scaffold/fields/post-post-article-settings.json
+++ b/scaffold/fields/post-post-article-settings.json
@@ -15,6 +15,11 @@
 			"serialize_data": false,
 			"add_to_prefix": false,
 			"children": {
+				"image_label": {
+          "label": { "__": "Enable Video Flag" },
+					"description": { "__": "Indicates that this is a video post." },
+					"type": "checkbox"
+				},
 				"dek": {
 					"label": { "__": "Deck" },
 					"type": "textarea",
@@ -39,11 +44,6 @@
 					"label": { "__": "Enable Label" },
 					"type": "checkboxes",
 					"options": "`\\Civil_First_Fleet\\Component\\Content_Item()->get_label_options()`"
-				},
-				"image_label": {
-					"label": { "__": "Enable Image Label" },
-					"type": "checkboxes",
-					"options": "`\\Civil_First_Fleet\\Component\\Content_Item()->get_image_label_options()`"
 				}
 			}
 		},


### PR DESCRIPTION
This PR refactors the video flag setting to use a single FM checkbox due to [a known issue with saving empty data to Fledmanager_Checkboxes](https://github.com/alleyinteractive/wordpress-fieldmanager/issues/764).

https://alleyinteractive.atlassian.net/browse/CDM-340